### PR TITLE
Change open shortcut to Crtl + Alt + K

### DIFF
--- a/src/KittopiaTech.cs
+++ b/src/KittopiaTech.cs
@@ -27,7 +27,7 @@ namespace KittopiaTech
         void Update()
         {
             // Check if the user wants to open the UI
-            if (Input.GetKey(KeyCode.LeftControl) && Input.GetKeyDown(KeyCode.LeftAlt)) && Input.GetKeyDown(KeyCode.K))
+            if (Input.GetKey(KeyCode.LeftControl) && Input.GetKeyDown(KeyCode.LeftAlt)) && Input.GetKeyDown(KeyCode.K) || (Input.GetKey(KeyCode.LeftControl) && (Input.GetKey(KeyCode.P)))
             {
                 // Open or close the main window
                 if (!PlanetSelector.Instance.IsOpen)

--- a/src/KittopiaTech.cs
+++ b/src/KittopiaTech.cs
@@ -27,7 +27,7 @@ namespace KittopiaTech
         void Update()
         {
             // Check if the user wants to open the UI
-            if (Input.GetKey(KeyCode.LeftControl) && Input.GetKeyDown(KeyCode.P))
+            if (Input.GetKey(KeyCode.LeftControl) && Input.GetKeyDown(KeyCode.LeftAlt)) && Input.GetKeyDown(KeyCode.K))
             {
                 // Open or close the main window
                 if (!PlanetSelector.Instance.IsOpen)


### PR DESCRIPTION
Parallax [unfortunately for Kittopia] uses Crtl + P, and I don't think Linx is willing to change the shortcut, so I have made this pull request to request to change it.